### PR TITLE
Hide original image after zoom

### DIFF
--- a/src/InnerImageZoom/InnerImageZoom.js
+++ b/src/InnerImageZoom/InnerImageZoom.js
@@ -253,6 +253,8 @@ class InnerImageZoom extends Component {
           sizes={sizes}
           sources={sources}
           alt={alt}
+          fadeDuration={this.props.fadeDuration}
+          isZoomed={this.state.isZoomed}
         />
 
         {this.state.isActive &&

--- a/src/InnerImageZoom/components/Image.js
+++ b/src/InnerImageZoom/components/Image.js
@@ -7,7 +7,9 @@ const Image = (props) => {
     srcSet,
     sizes,
     sources,
-    alt
+    alt,
+    isZoomed,
+    fadeDuration
   } = props;
 
   return(
@@ -30,7 +32,10 @@ const Image = (props) => {
           })}
 
           <img
-            className="iiz__img"
+            className={`iiz__img ${isZoomed ? 'iiz__img--invisible' : ''}`}
+            style={{
+              transition: `linear ${fadeDuration}ms opacity, linear ${fadeDuration}ms visibility`
+            }}
             src={src}
             srcSet={srcSet}
             sizes={sizes}
@@ -39,7 +44,10 @@ const Image = (props) => {
         </picture>
       ) : (
         <img
-          className="iiz__img"
+          className={`iiz__img ${isZoomed ? 'iiz__img--invisible' : ''}`}
+          style={{
+            transition: `linear ${fadeDuration}ms opacity, linear ${fadeDuration}ms visibility`
+          }}
           src={src}
           srcSet={srcSet}
           sizes={sizes}
@@ -55,7 +63,8 @@ Image.propTypes = {
   srcSet: PropTypes.string,
   sizes: PropTypes.string,
   sources: PropTypes.array,
-  alt: PropTypes.string
+  alt: PropTypes.string,
+  isZoomed: PropTypes.bool
 };
 
 export default Image;

--- a/src/InnerImageZoom/styles.css
+++ b/src/InnerImageZoom/styles.css
@@ -11,6 +11,13 @@
   height: auto;
   display: block;
   pointer-events: none;
+  visibility: visible;
+  opacity: 1;
+}
+
+.iiz__img--invisible {
+  visibility: hidden;
+  opacity: 0;
 }
 
 .iiz__zoom-img {


### PR DESCRIPTION
Hey!

Sometimes when image has a big transparent border, we're seeing original image after zoom and moving zoomed image around. So we need to hide the original image after zooming image.