### PR TITLE
Include styles in dist after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "umd"
   ],
   "scripts": {
-    "build": "nwb build-react-component",
+    "build": "nwb build-react-component --copy-files",
     "clean": "nwb clean-module && nwb clean-demo",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",


### PR DESCRIPTION
Hey!

It would be nice to include style directly from project and not copy all styles, something like this:

```js
import 'react-inner-image-zoom/es/InnerImageZoom/styles.css';
```

This change will include css files in dist folder.